### PR TITLE
feat: 세미나 카드 뷰에 세미나 개최자 정보 넣기

### DIFF
--- a/app/src/main/java/com/semina/semi_na/data/db/entity/HobbyCategory.java
+++ b/app/src/main/java/com/semina/semi_na/data/db/entity/HobbyCategory.java
@@ -2,6 +2,15 @@ package com.semina.semi_na.data.db.entity;
 
 public enum HobbyCategory {
 
-    EXERCISE, FOOD, MUSIC, BOOK, NULL
+    EXERCISE("운동"), FOOD("요리"), MUSIC("음악"), BOOK("독서"), NULL("분류없음");
+    private String hobbyName;
+
+    HobbyCategory(String hobbyName) {
+        this.hobbyName = hobbyName;
+    }
+
+    public String getHobbyName() {
+        return hobbyName;
+    }
 
 }

--- a/app/src/main/java/com/semina/semi_na/data/db/entity/MajorCategory.java
+++ b/app/src/main/java/com/semina/semi_na/data/db/entity/MajorCategory.java
@@ -1,5 +1,14 @@
 package com.semina.semi_na.data.db.entity;
 
 public enum MajorCategory {
-    IT,ENGINEERING,BUSINESS,SCIENCE, SOCIAL,HUMANITY,LAW,ECONOMIC,NULL
+    IT("IT대학"), ENGINEERING("공과대학"), BUSINESS("경영대학"), SCIENCE("자연과학대학"), SOCIAL("사회과학대학"), HUMANITY("인문대학"), LAW("법과대학"), ECONOMIC("경제통상대학"), NULL("분류없음");
+    private String majorName;
+
+    MajorCategory(String majorName) {
+        this.majorName = majorName;
+    }
+
+    public String getMajorName() {
+        return majorName;
+    }
 }

--- a/app/src/main/java/com/semina/semi_na/data/db/entity/Member.java
+++ b/app/src/main/java/com/semina/semi_na/data/db/entity/Member.java
@@ -14,7 +14,7 @@ public class Member implements Serializable {
 
     private String major;
 
-    public Member(String studentNum,String department,String name,String major,String fcmToken){
+    public Member(String studentNum, String department, String name, String major, String fcmToken) {
         this.studentNum = studentNum;
         this.department = department;
         this.name = name;
@@ -22,19 +22,23 @@ public class Member implements Serializable {
         this.fcmToken = fcmToken;
     }
 
+    public Member() {
+
+    }
+
     public String getStudentNum() {
         return studentNum;
     }
 
-    public String getDepartment(){
+    public String getDepartment() {
         return department;
     }
 
-    public String getName(){
+    public String getName() {
         return name;
     }
 
-    public String getMajor(){
+    public String getMajor() {
         return major;
     }
 

--- a/app/src/main/java/com/semina/semi_na/data/db/entity/Semina.java
+++ b/app/src/main/java/com/semina/semi_na/data/db/entity/Semina.java
@@ -27,8 +27,8 @@ public class Semina implements Serializable {
     private String description;
     private int capacity;
 
-    public Semina(String title, SeminaCategory seminaCategory,MajorCategory majorCategory,String date,String time, String host,String imgUrl,Location location,String locationDetail
-    ,ArrayList<String> memberList,int capacity,HobbyCategory hobbyCategory){
+    public Semina(String title, SeminaCategory seminaCategory, MajorCategory majorCategory, String date, String time, String host, String imgUrl, Location location, String locationDetail
+            , ArrayList<String> memberList, int capacity, HobbyCategory hobbyCategory) {
         this.title = title;
         this.seminaCategory = seminaCategory;
         this.majorCategory = majorCategory;
@@ -135,11 +135,15 @@ public class Semina implements Serializable {
         return capacity;
     }
 
-    public HobbyCategory getHobbyCategory() {
-        return hobbyCategory;
-    }
-
     public String getDate() {
         return date;
+    }
+
+    public MajorCategory getMajorCategory() {
+        return majorCategory;
+    }
+
+    public HobbyCategory getHobbyCategory() {
+        return hobbyCategory;
     }
 }

--- a/app/src/main/java/com/semina/semi_na/data/db/entity/SeminaCategory.java
+++ b/app/src/main/java/com/semina/semi_na/data/db/entity/SeminaCategory.java
@@ -1,5 +1,5 @@
 package com.semina.semi_na.data.db.entity;
 
 public enum SeminaCategory {
-    MAJOR,HOBBY
+    MAJOR, HOBBY
 }

--- a/app/src/main/java/com/semina/semi_na/view/create/CreateMajorActivity.java
+++ b/app/src/main/java/com/semina/semi_na/view/create/CreateMajorActivity.java
@@ -22,7 +22,7 @@ import com.semina.semi_na.data.db.entity.Semina;
 import com.semina.semi_na.databinding.ActivityCreateHobbyBinding;
 import com.semina.semi_na.databinding.ActivityCreateMajorBinding;
 
-public class CreateMajorActivity extends AppCompatActivity{
+public class CreateMajorActivity extends AppCompatActivity {
 
     private ActivityCreateMajorBinding binding;
     private Intent intent;
@@ -50,10 +50,10 @@ public class CreateMajorActivity extends AppCompatActivity{
             @Override
             public void onClick(View view) {
                 binding.createMajorIt.setSelected(!view.isSelected());
-                if(binding.createMajorIt.isSelected()){
+                if (binding.createMajorIt.isSelected()) {
                     majorCategory = MajorCategory.IT;
                     binding.createMajorIt.setBackground(getDrawable(R.drawable.tab_selected_background));
-                }else{
+                } else {
                     binding.createMajorIt.setBackground(null);
                 }
             }
@@ -62,10 +62,10 @@ public class CreateMajorActivity extends AppCompatActivity{
             @Override
             public void onClick(View view) {
                 binding.createMajorEngineer.setSelected(!view.isSelected());
-                if(binding.createMajorEngineer.isSelected()){
+                if (binding.createMajorEngineer.isSelected()) {
                     majorCategory = MajorCategory.ENGINEERING;
                     binding.createMajorEngineer.setBackground(getDrawable(R.drawable.tab_selected_background));
-                }else{
+                } else {
                     binding.createMajorEngineer.setBackground(null);
                 }
             }
@@ -75,10 +75,10 @@ public class CreateMajorActivity extends AppCompatActivity{
             @Override
             public void onClick(View view) {
                 binding.createMajorBusiness.setSelected(!view.isSelected());
-                if(binding.createMajorBusiness.isSelected()){
+                if (binding.createMajorBusiness.isSelected()) {
                     majorCategory = MajorCategory.BUSINESS;
                     binding.createMajorBusiness.setBackground(getDrawable(R.drawable.tab_selected_background));
-                }else{
+                } else {
                     binding.createMajorBusiness.setBackground(null);
                 }
             }
@@ -88,10 +88,10 @@ public class CreateMajorActivity extends AppCompatActivity{
             @Override
             public void onClick(View view) {
                 binding.createMajorEconomic.setSelected(!view.isSelected());
-                if(binding.createMajorEconomic.isSelected()){
+                if (binding.createMajorEconomic.isSelected()) {
                     majorCategory = MajorCategory.ENGINEERING;
                     binding.createMajorEconomic.setBackground(getDrawable(R.drawable.tab_selected_background));
-                }else{
+                } else {
                     binding.createMajorEconomic.setBackground(null);
                 }
             }
@@ -100,10 +100,10 @@ public class CreateMajorActivity extends AppCompatActivity{
             @Override
             public void onClick(View view) {
                 binding.createMajorLaw.setSelected(!view.isSelected());
-                if(binding.createMajorLaw.isSelected()){
+                if (binding.createMajorLaw.isSelected()) {
                     majorCategory = MajorCategory.HUMANITY;
                     binding.createMajorLaw.setBackground(getDrawable(R.drawable.tab_selected_background));
-                }else{
+                } else {
                     binding.createMajorLaw.setBackground(null);
                 }
             }
@@ -112,10 +112,10 @@ public class CreateMajorActivity extends AppCompatActivity{
             @Override
             public void onClick(View view) {
                 binding.createMajorHumanity.setSelected(!view.isSelected());
-                if(binding.createMajorHumanity.isSelected()){
+                if (binding.createMajorHumanity.isSelected()) {
                     majorCategory = MajorCategory.HUMANITY;
                     binding.createMajorHumanity.setBackground(getDrawable(R.drawable.tab_selected_background));
-                }else{
+                } else {
                     binding.createMajorHumanity.setBackground(null);
                 }
             }
@@ -124,10 +124,10 @@ public class CreateMajorActivity extends AppCompatActivity{
             @Override
             public void onClick(View view) {
                 binding.createMajorScience.setSelected(!view.isSelected());
-                if(binding.createMajorScience.isSelected()){
+                if (binding.createMajorScience.isSelected()) {
                     majorCategory = MajorCategory.SCIENCE;
                     binding.createMajorScience.setBackground(getDrawable(R.drawable.tab_selected_background));
-                }else{
+                } else {
                     binding.createMajorScience.setBackground(null);
                 }
             }
@@ -136,10 +136,10 @@ public class CreateMajorActivity extends AppCompatActivity{
             @Override
             public void onClick(View view) {
                 binding.createMajorSocial.setSelected(!view.isSelected());
-                if(binding.createMajorSocial.isSelected()){
+                if (binding.createMajorSocial.isSelected()) {
                     majorCategory = MajorCategory.SOCIAL;
                     binding.createMajorSocial.setBackground(getDrawable(R.drawable.tab_selected_background));
-                }else{
+                } else {
                     binding.createMajorSocial.setBackground(null);
                 }
             }
@@ -151,11 +151,11 @@ public class CreateMajorActivity extends AppCompatActivity{
             public void onClick(View view) {
                 intent = getIntent();
                 Semina semina = (Semina) intent.getSerializableExtra("semina");
-                if(majorCategory==MajorCategory.NULL){
+                if (majorCategory == MajorCategory.NULL) {
                     showToast("전공을 선택해주세요");
-                }else{
+                } else {
                     semina.setMajorCategory(majorCategory);
-                    launcher.launch(new Intent(getApplicationContext(),CreateLocationActivity.class).putExtra("semina",semina)
+                    launcher.launch(new Intent(getApplicationContext(), CreateLocationActivity.class).putExtra("semina", semina)
                             .addFlags(Intent.FLAG_ACTIVITY_NO_HISTORY));
                 }
             }
@@ -163,9 +163,9 @@ public class CreateMajorActivity extends AppCompatActivity{
 
     }
 
-   public void showToast(String msg){
-       Toast.makeText(getApplicationContext(),msg,Toast.LENGTH_LONG).show();
-   }
+    public void showToast(String msg) {
+        Toast.makeText(getApplicationContext(), msg, Toast.LENGTH_LONG).show();
+    }
 
     // 어떤 이넘 카테고리가 press됐는지에 따라 -> background stroke 정해준다.
 

--- a/app/src/main/java/com/semina/semi_na/view/create/CreateTitleActivity.java
+++ b/app/src/main/java/com/semina/semi_na/view/create/CreateTitleActivity.java
@@ -38,9 +38,9 @@ public class CreateTitleActivity extends AppCompatActivity {
         editTitle = binding.createTitleEdit;
         title = "";
         sharedPreferences = getSharedPreferences("UserInfo", MODE_PRIVATE);
-        studentNum = sharedPreferences.getString("studentNum","");
+        studentNum = sharedPreferences.getString("studentNum", "");
 
-        Log.d("CreateTitleActivity",title);
+        Log.d("CreateTitleActivity", title);
 
         ActivityResultLauncher<Intent> launcher = registerForActivityResult(new ActivityResultContracts.StartActivityForResult(),
                 new ActivityResultCallback<ActivityResult>() {
@@ -53,19 +53,18 @@ public class CreateTitleActivity extends AppCompatActivity {
                 });
 
 
-
-        nextButton.setOnClickListener(view->{
+        nextButton.setOnClickListener(view -> {
             title = String.valueOf(editTitle.getText());
-            Log.d("CreateTitleActivity",title);
+            Log.d("CreateTitleActivity", title);
 
-            if(title.equals("")){
+            if (title.equals("")) {
                 showToast("세미나 이름을 적어주세요");
-            }else{
+            } else {
                 Semina semina = new Semina();
                 semina.setHost(studentNum);
                 semina.setTitle(title);
-                Log.d("CreateTitleActivity",semina.getHost());
-                launcher.launch(new Intent(getApplicationContext(),CreateCategoryActivity.class).putExtra("semina",semina)
+                Log.d("CreateTitleActivity", semina.getHost());
+                launcher.launch(new Intent(getApplicationContext(), CreateCategoryActivity.class).putExtra("semina", semina)
                         .addFlags(Intent.FLAG_ACTIVITY_NO_HISTORY));
                 //startActivityForResult(new Intent(getApplicationContext(), CreateCategoryActivity.class));
             }
@@ -75,7 +74,7 @@ public class CreateTitleActivity extends AppCompatActivity {
 
     // @TODO ActivityForResult Register 어쩌구저쩌구 하기
 
-    public void showToast(String msg){
-        Toast.makeText(getApplicationContext(),msg,Toast.LENGTH_LONG).show();
+    public void showToast(String msg) {
+        Toast.makeText(getApplicationContext(), msg, Toast.LENGTH_LONG).show();
     }
 }


### PR DESCRIPTION
## ISSUE_NUM: resolve #39 

### Description
- [x] 세미나 호스트(학번) 정보로 파이어스토어에서 해당 학번의 멤버 정보 받아오기
- [x] 받아온 멤버 정보를 세미나 카드 뷰에 뿌려주기
- [x] `MajorCategory`, `HobbyCategory` enum에 한글 이름 추가

### ScreenShot
<img src="https://github.com/Sem-in-a/Semi-na-android/assets/76615094/89b31034-3353-459a-81e0-9d7973485efa" width="300">
